### PR TITLE
switchport status and config  command improvement by 15 times

### DIFF
--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -506,23 +506,21 @@ def get_interface_tagged_vlan_members(db, interface):
     return "\n".join(formatted_tagged_vlans)
 
 
-def get_interface_switchport_mode(db, interface):
-    port = db.cfgdb.get_entry('PORT', interface)
-    portchannel = db.cfgdb.get_entry('PORTCHANNEL', interface)
-    vlan_member_table = db.cfgdb.get_table('VLAN_MEMBER')
-
-    vlan_member_keys = []
-    for _, key in vlan_member_table:
-        vlan_member_keys.append(key)
-
-    switchport_mode = 'routed'
-    if "mode" in port:
-        switchport_mode = port['mode']
-    elif "mode" in portchannel:
-        switchport_mode = portchannel['mode']
-    elif interface in vlan_member_keys:
-        switchport_mode = 'trunk'
-    return switchport_mode
+def get_interface_switchport_mode(db, interface, vlan_member_keys=None, port=None):
+    if port is None:
+        port = db.cfgdb.get_table('PORT')
+    if "mode" in port[interface]:
+        return port[interface]['mode']
+    elif vlan_member_keys is None:
+        vlan_member_table = db.cfgdb.get_table('VLAN_MEMBER')
+        vlan_member_keys = [key for _, key in vlan_member_table]
+        if interface in vlan_member_keys:
+            return 'trunk'
+    else:
+        portchannel = db.cfgdb.get_entry('PORTCHANNEL', interface)
+        if "mode" in portchannel:
+            return portchannel['mode']
+    return 'routed'
 
 
 def is_port_mirror_dst_port(config_db, port):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Optimize the code, getting 15 times performance improvement
#### How I did it


#### How to verify it
`time show int switchport config
`
#### Previous command output (if the output of a command-line utility has changed)
```
admin@str-7060x6-64pe-stress-01:~$ time show int switchport config
Interface    Mode    Untagged    Tagged
-----------  ------  ----------  --------
Ethernet0    routed  2
Ethernet1    routed  2
Ethernet16   routed
Ethernet17   routed
...
....

Ethernet112  routed  2
....
.....
Ethernet499  routed
Ethernet500  routed              2
Ethernet501  routed
Ethernet502  routed
Ethernet503  routed
Ethernet512  routed
Ethernet513  routed

real    0m12.485s
user    0m5.013s
sys     0m2.697s
admin@str-7060x6-64pe-stress-01:~$
```
#### New command output (if the output of a command-line utility has changed)
```
admin@sonic-s6100-dut1:~$ time show int switchport config
Interface    Mode    Untagged    Tagged
-----------  ------  ----------  --------
Ethernet0    routed  2
Ethernet1    routed  2
Ethernet16   routed
Ethernet17   routed
...
....

Ethernet112  routed  2
....
.....
Ethernet499  routed
Ethernet500  routed              2
Ethernet501  routed
Ethernet502  routed
Ethernet503  routed
Ethernet512  routed
Ethernet513  routed

real    0m0.824s
user    0m0.512s
sys     0m0.195s
admin@sonic-s6100-dut1:~$
```