### PR TITLE
Added json support for intfutil

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -27,6 +27,7 @@ from tabulate import tabulate
 from utilities_common import constants
 from utilities_common import multi_asic as multi_asic_util
 from utilities_common.intf_filter import parse_interface_in_filter
+from utilities_common.netstat import table_as_json
 from utilities_common.platform_sfputil_helper import is_rj45_port, RJ45_PORT_TYPE
 from sonic_py_common.interface import get_intf_longname
 from sonic_py_common import multi_asic
@@ -422,7 +423,7 @@ header_stat_sub_intf = ['Sub port interface', 'Speed', 'MTU', 'Vlan', 'Admin', '
 
 class IntfStatus(object):
 
-    def __init__(self, intf_name, namespace_option, display_option):
+    def __init__(self, intf_name, namespace_option, display_option, use_json=False):
         """
         Class constructor method
         :param self:
@@ -434,6 +435,7 @@ class IntfStatus(object):
         self.sub_intf_only = False
         self.intf_name = intf_name
         self.sub_intf_name = intf_name
+        self.use_json = use_json
         self.table = []
         self.multi_asic = multi_asic_util.MultiAsic(
             display_option, namespace_option)
@@ -451,10 +453,13 @@ class IntfStatus(object):
     def display_intf_status(self):
         self.get_intf_status()
         sorted_table = natsorted(self.table)
-        print(tabulate(sorted_table,
-                       header_stat if not self.sub_intf_only else header_stat_sub_intf,
-                       tablefmt="simple",
-                       stralign='right'))
+        if self.use_json:
+            print(table_as_json(sorted_table, header_stat if not self.sub_intf_only else header_stat_sub_intf))
+        else:
+            print(tabulate(sorted_table,
+                        header_stat if not self.sub_intf_only else header_stat_sub_intf,
+                        tablefmt="simple",
+                        stralign='right'))
 
     def generate_intf_status(self):
         """
@@ -546,10 +551,11 @@ header_desc = ['Interface', 'Oper', 'Admin', 'Alias', 'Description']
 
 class IntfDescription(object):
 
-    def __init__(self, intf_name, namespace_option, display_option):
+    def __init__(self, intf_name, namespace_option, display_option, use_json=False):
         self.db = None
         self.config_db = None
         self.table = []
+        self.use_json = use_json
         self.multi_asic = multi_asic_util.MultiAsic(
             display_option, namespace_option)
 
@@ -564,7 +570,10 @@ class IntfDescription(object):
 
         # Sorting and tabulating the result table.
         sorted_table = natsorted(self.table)
-        print(tabulate(sorted_table, header_desc, tablefmt="simple", stralign='right'))
+        if self.use_json:
+            print(table_as_json(sorted_table, header_desc))
+        else:
+            print(tabulate(sorted_table, header_desc, tablefmt="simple", stralign='right'))
 
     def generate_intf_description(self):
         """
@@ -605,10 +614,11 @@ header_autoneg = ['Interface', 'Auto-Neg Mode', 'Speed', 'Adv Speeds', 'Rmt Adv 
 
 class IntfAutoNegStatus(object):
 
-    def __init__(self, intf_name, namespace_option, display_option):
+    def __init__(self, intf_name, namespace_option, display_option, use_json=False):
         self.db = None
         self.config_db = None
         self.table = []
+        self.use_json = use_json
         self.multi_asic = multi_asic_util.MultiAsic(
             display_option, namespace_option)
 
@@ -623,7 +633,10 @@ class IntfAutoNegStatus(object):
 
         # Sorting and tabulating the result table.
         sorted_table = natsorted(self.table)
-        print(tabulate(sorted_table, header_autoneg, tablefmt="simple", stralign='right'))
+        if self.use_json:
+            print(table_as_json(sorted_table, header_autoneg))
+        else:
+            print(tabulate(sorted_table, header_autoneg, tablefmt="simple", stralign='right'))
 
     def generate_autoneg_status(self):
         """
@@ -672,7 +685,7 @@ header_tpid = ['Interface', 'Alias', 'Oper', 'Admin', 'TPID']
 
 class IntfTpid(object):
 
-    def __init__(self, intf_name, namespace_option, display_option):
+    def __init__(self, intf_name, namespace_option, display_option, use_json=False):
         """
         Class constructor method
         :param self:
@@ -683,6 +696,7 @@ class IntfTpid(object):
         self.config_db = None
         self.intf_name = intf_name
         self.table = []
+        self.use_json = use_json
         self.multi_asic = multi_asic_util.MultiAsic(
             display_option, namespace_option)
 
@@ -694,7 +708,10 @@ class IntfTpid(object):
 
         # Sorting and tabulating the result table.
         sorted_table = natsorted(self.table)
-        print(tabulate(sorted_table, header_tpid, tablefmt="simple", stralign='right'))
+        if self.use_json:
+            print(table_as_json(sorted_table, header_tpid))
+        else:
+            print(tabulate(sorted_table, header_tpid, tablefmt="simple", stralign='right'))
 
     def generate_intf_tpid(self):
         """
@@ -756,10 +773,11 @@ header_link_training = ['Interface', 'LT Oper', 'LT Admin', 'Oper', 'Admin']
 
 class IntfLinkTrainingStatus(object):
 
-    def __init__(self, intf_name, namespace_option, display_option):
+    def __init__(self, intf_name, namespace_option, display_option, use_json=False):
         self.db = None
         self.config_db = None
         self.table = []
+        self.use_json = use_json
         self.multi_asic = multi_asic_util.MultiAsic(
             display_option, namespace_option)
 
@@ -772,7 +790,10 @@ class IntfLinkTrainingStatus(object):
         self.get_intf_link_training_status()
         # Sorting and tabulating the result table.
         sorted_table = natsorted(self.table)
-        print(tabulate(sorted_table, header_link_training, tablefmt="simple", stralign='right'))
+        if self.use_json:
+            print(table_as_json(sorted_table, header_link_training))
+        else:
+            print(tabulate(sorted_table, header_link_training, tablefmt="simple", stralign='right'))
 
     @multi_asic_util.run_on_multi_asic
     def get_intf_link_training_status(self):
@@ -815,10 +836,11 @@ header_fec = ['Interface', 'FEC Oper', 'FEC Admin']
 
 class IntfFecStatus(object):
 
-    def __init__(self, intf_name, namespace_option, display_option):
+    def __init__(self, intf_name, namespace_option, display_option, use_json=False):
         self.db = None
         self.config_db = None
         self.table = []
+        self.use_json = use_json
         self.multi_asic = multi_asic_util.MultiAsic(
             display_option, namespace_option)
 
@@ -831,7 +853,10 @@ class IntfFecStatus(object):
         self.get_intf_fec_status()
         # Sorting and tabulating the result table.
         sorted_table = natsorted(self.table)
-        print(tabulate(sorted_table, header_fec, tablefmt="simple", stralign='right'))
+        if self.use_json:
+            print(table_as_json(sorted_table, header_fec))
+        else:
+            print(tabulate(sorted_table, header_fec, tablefmt="simple", stralign='right'))
 
     @multi_asic_util.run_on_multi_asic
     def get_intf_fec_status(self):
@@ -872,26 +897,26 @@ def main():
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('-c', '--command', type=str, help='get interface status or description or auto negotiation status or tpid', default=None)
     parser.add_argument('-i', '--interface', type=str, help='interface information for specific port: Ethernet0', default=None)
+    parser.add_argument('-j', '--json', action='store_true', help='Display in JSON format')
     parser = multi_asic_util.multi_asic_args(parser)
     args = parser.parse_args()
-
     if args.command == "status":
-        interface_stat = IntfStatus(args.interface, args.namespace, args.display)
+        interface_stat = IntfStatus(args.interface, args.namespace, args.display, args.json)
         interface_stat.display_intf_status()
     elif args.command == "description":
-        interface_desc = IntfDescription(args.interface, args.namespace, args.display)
+        interface_desc = IntfDescription(args.interface, args.namespace, args.display, args.json)
         interface_desc.display_intf_description()
     elif args.command == "autoneg":
-        interface_autoneg_status = IntfAutoNegStatus(args.interface, args.namespace, args.display)
+        interface_autoneg_status = IntfAutoNegStatus(args.interface, args.namespace, args.display, args.json)
         interface_autoneg_status.display_autoneg_status()
     elif args.command == "tpid":
-        interface_tpid = IntfTpid(args.interface, args.namespace, args.display)
+        interface_tpid = IntfTpid(args.interface, args.namespace, args.display, args.json)
         interface_tpid.display_intf_tpid()
     elif args.command == "link_training":
-        interface_lt_status = IntfLinkTrainingStatus(args.interface, args.namespace, args.display)
+        interface_lt_status = IntfLinkTrainingStatus(args.interface, args.namespace, args.display, args.json)
         interface_lt_status.display_link_training_status()
     elif args.command == "fec":
-        interface_fec_status = IntfFecStatus(args.interface, args.namespace, args.display)
+        interface_fec_status = IntfFecStatus(args.interface, args.namespace, args.display, args.json)
         interface_fec_status.display_fec_status()
 
     sys.exit(0)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added json output supoort for
```
intfutil -c autoneg -j
intfutil -c fec -j
intfutil -c status -j
intfutil -c description -j
intfutil -c tpid -j
intfutil -c link_training -j

```
#### How I did it

#### How to verify it
```
admin@str-7060x6-64pe-stress-01:~$ intfutil -c status -i Ethernet0 -j
{
    "Ethernet0": {
        "Admin": "up",
        "Alias": "Ethernet1/1",
        "Asym PFC": "off",
        "FEC": "rs",
        "Lanes": "17",
        "MTU": "9100",
        "Oper": "up",
        "Speed": "100G",
        "Type": "OSFP 8X Pluggable Transceiver",
        "Vlan": "trunk"
    }
}
admin@str-7060x6-64pe-stress-01:~$ intfutil -c description -i Ethernet0 -j
{
    "Ethernet0": {
        "Admin": "up",
        "Alias": "Ethernet1/1",
        "Description": "Servers0:eth0",
        "Oper": "up"
    }
}
admin@str-7060x6-64pe-stress-01:~$ intfutil -c autoneg -i Ethernet0 -j
{
    "Ethernet0": {
        "Admin": "up",
        "Adv Speeds": "N/A",
        "Adv Types": "N/A",
        "Auto-Neg Mode": "N/A",
        "Oper": "up",
        "Rmt Adv Speeds": "N/A",
        "Speed": "100G",
        "Type": "N/A"
    }
}
admin@str-7060x6-64pe-stress-01:~$ intfutil -c tpid -i Ethernet0 -j
{
    "Ethernet0": {
        "Admin": "up",
        "Alias": "Ethernet1/1",
        "Oper": "up",
        "TPID": "0x8100"
    }
}
admin@str-7060x6-64pe-stress-01:~$ intfutil -c link_training -i Ethernet0 -j
{
    "Ethernet0": {
        "Admin": "up",
        "LT Admin": "N/A",
        "LT Oper": "N/A",
        "Oper": "up"
    }
}
admin@str-7060x6-64pe-stress-01:~$ intfutil -c fec -i Ethernet0 -j
{
    "Ethernet0": {
        "FEC Admin": "rs",
        "FEC Oper": "N/A"
    }
}

```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

